### PR TITLE
Added S3 query to identify buckets relying on ACLs

### DIFF
--- a/s3-buckets-using-acls.sql
+++ b/s3-buckets-using-acls.sql
@@ -1,0 +1,16 @@
+/* This query identifies buckets across an Organization with requests that rely on ACLs. This can help when migrating away from legacy ACLs to IAM Policies.
+
+Replace <EDS ID> with your Event Data Store ID number.
+*/
+
+SELECT DISTINCT
+    element_at(requestParameters, 'bucketName') AS Bucket,
+    awsRegion AS Region,
+    recipientAccountId AS AccountID
+FROM
+    <EDS_ID> 
+WHERE
+	element_at(additionalEventData, 'aclRequired') = 'Yes'
+ORDER BY
+	recipientAccountId,
+    awsRegion

--- a/s3-buckets-using-acls.sql
+++ b/s3-buckets-using-acls.sql
@@ -10,7 +10,7 @@ SELECT DISTINCT
 FROM
     <EDS_ID> 
 WHERE
-	element_at(additionalEventData, 'aclRequired') = 'Yes'
+    element_at(additionalEventData, 'aclRequired') = 'Yes'
 ORDER BY
-	recipientAccountId,
+    recipientAccountId,
     awsRegion


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Leverages the new [S3 request-level information](https://aws.amazon.com/about-aws/whats-new/2022/11/s3-request-level-information-access-control-lists-acls-s3-server-access-logs-cloudtrail/) to identify buckets across an Organization with requests that rely on ACLs. This can help when migrating away from legacy ACLs to IAM Policies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
