### PR TITLE
Added CloudFormation StackSets investigation sample

### DIFF
--- a/cloudformation-stacksets-service-managed-investigation.sql
+++ b/cloudformation-stacksets-service-managed-investigation.sql
@@ -1,0 +1,38 @@
+/* This query identifies the source StackSet for an operation performed using StackSets with Service-Managed permissions.
+Replace <$EDS_ID> with your Event Data Store Id number
+Replace <$EVENT_ID> with the eventID of the beginning event
+Replace eventTime dates to scope the search to a specific time range
+*/
+
+
+SELECT
+    userIdentity.principalId,
+    element_at(requestParameters, 'stackSetName') as stackSetName,
+    eventName,
+    eventTime,
+    sourceIPAddress
+FROM
+    $EDS_ID 
+WHERE
+    eventName LIKE '%StackSet'
+    AND eventTime > '2024-10-20 00:00:00'  
+    AND eventTime < '2024-10-25 00:00:00'
+    AND element_at(requestParameters, 'stackSetName') IN (
+        SELECT
+            regexp_replace(
+                element_at(requestParameters, 'stackName'),
+                '^StackSet-|(-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$'
+            ) AS stackName
+        FROM 
+            $EDS_ID
+        WHERE 
+            eventName LIKE '%Stack'
+            AND userIdentity.principalId IN (
+                SELECT 
+                    userIdentity.principalid
+                FROM
+                    $EDS_ID
+                WHERE
+                    eventID = $EVENT_ID
+            )
+    )


### PR DESCRIPTION
*Description of changes:* Created sample to assist customers in the end-to-end traceability of actions done by CloudFormation StackSets with Service-Managed Identities.

When using Service-Managed Identities, the source identity is abstracted away from the actual end API calls behind a principalId of `stacksets-exec-*`, making end-to-end traceability and accountability difficult and having to correlate multiple different events to arrive at the "who did it?". This sample uses nested queries to arrive at that in a single pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
